### PR TITLE
adding lit-analyzer

### DIFF
--- a/src/generators/default-content/templates/configured/_package.json
+++ b/src/generators/default-content/templates/configured/_package.json
@@ -3,8 +3,9 @@
   "description": "<%= description %>",
   "repository": "https://github.com/<%= githubOrg %>/<%= hyphenatedName %>.git",
   "scripts": {
-    "lint": "npm run lint:eslint && npm run lint:style",
+    "lint": "npm run lint:eslint && npm run lint:lit && npm run lint:style",
     "lint:eslint": "eslint . --ext .js,.html",
+    "lint:lit": "lit-analyzer <%= hyphenatedName %>.js --strict",
     "lint:style": "stylelint \"**/*.js\""
   },
   "author": "D2L Corporation",
@@ -17,6 +18,7 @@
     "eslint-plugin-html": "^6",
     "eslint-plugin-lit": "^1",
     "eslint-plugin-sort-class-members": "^1",
+    "lit-analyzer": "^1",
     "stylelint": "^13"
   },
   "files": [


### PR DESCRIPTION
Thought about putting this in the `wc-lit-element` template (and I still can), but it complicated matters in that the `npm run lint` script would need to somehow merge it in.