### PR TITLE
replacing after copy

### DIFF
--- a/src/generators/default-content/index.js
+++ b/src/generators/default-content/index.js
@@ -4,11 +4,11 @@ export function run(templateData) {
 
 	const replacementsPackage = templateData;
 	replacementsPackage.locales = templateData.localization && templateData.localizationType !== 'static' ? ',\n"/locales"' : '';
-	replaceText(`${__dirname}/templates/configured/_package.json`, replacementsPackage);
 	copyFile(
 		`${__dirname}/templates/configured/_package.json`,
 		`${getDestinationPath(templateData.hyphenatedName)}/package.json`
 	);
+	replaceText(`${getDestinationPath(templateData.hyphenatedName)}/package.json`, replacementsPackage);
 
 	const replacementsREADME = templateData;
 	replacementsREADME.labsChecklist = templateData.org === 'labs' ? `\n> Note: this is a ["labs" component](https://github.com/BrightspaceUI/guide/wiki/Component-Tiers). While functional, these tasks are prerequisites to promotion to BrightspaceUI "official" status:
@@ -26,25 +26,25 @@ export function run(templateData) {
 > - [ ] README documentation\n` : '';
 
 	if (templateData.description) replacementsREADME.description = `\n${templateData.description}\n`;
-	replaceText(`${__dirname}/templates/configured/_README.md`, replacementsREADME);
 	copyFile(
 		`${__dirname}/templates/configured/_README.md`,
 		`${getDestinationPath(templateData.hyphenatedName)}/README.md`
 	);
+	replaceText(`${getDestinationPath(templateData.hyphenatedName)}/README.md`, replacementsREADME);
 
 	if (templateData.codeowners) {
-		replaceText(`${__dirname}/templates/configured/_CODEOWNERS`, { codeowners: templateData.codeowners });
 		copyFile(
 			`${__dirname}/templates/configured/_CODEOWNERS`,
 			`${getDestinationPath(templateData.hyphenatedName)}/CODEOWNERS`
 		);
+		replaceText(`${getDestinationPath(templateData.hyphenatedName)}/CODEOWNERS`, { codeowners: templateData.codeowners });
 	}
 
-	replaceText(`${__dirname}/templates/configured/LICENSE`, { year: new Date().getFullYear().toString() });
 	copyFile(
 		`${__dirname}/templates/configured/LICENSE`,
 		`${getDestinationPath(templateData.hyphenatedName)}/LICENSE`
 	);
+	replaceText(`${getDestinationPath(templateData.hyphenatedName)}/LICENSE`, { year: new Date().getFullYear().toString() });
 
 	copyFilesInDir(`${__dirname}/templates/static`, getDestinationPath(templateData.hyphenatedName));
 }

--- a/src/generators/demo/index.js
+++ b/src/generators/demo/index.js
@@ -10,9 +10,9 @@ export function run(templateData) {
 		`${getDestinationPath(templateData.hyphenatedName)}/README.md`
 	);
 
-	replaceText(`${__dirname}/templates/index.html`, templateData);
 	copyFile(
 		`${__dirname}/templates/index.html`,
 		`${getDestinationPath(templateData.hyphenatedName)}/demo/index.html`
 	);
+	replaceText(`${getDestinationPath(templateData.hyphenatedName)}/demo/index.html`, templateData);
 }

--- a/src/generators/localization/index.js
+++ b/src/generators/localization/index.js
@@ -36,10 +36,10 @@ export function run(templateData) {
 	replaceText(`${getDestinationPath(templateData.hyphenatedName)}/${templateData.hyphenatedName}.js`, replacements);
 
 	if (templateData.localizationType === 'serge') {
-		replaceText(`${__dirname}/templates/configured/_element.serge.json`, templateData);
 		copyFile(
 			`${__dirname}/templates/configured/_element.serge.json`,
 			`${getDestinationPath(templateData.hyphenatedName)}/${templateData.hyphenatedName}.serge.json`
 		);
+		replaceText(`${getDestinationPath(templateData.hyphenatedName)}/${templateData.hyphenatedName}.serge.json`, templateData);
 	}
 }

--- a/src/generators/test-unit/index.js
+++ b/src/generators/test-unit/index.js
@@ -10,11 +10,11 @@ export function run(templateData) {
 		`${getDestinationPath(templateData.hyphenatedName)}/README.md`
 	);
 
-	replaceText(`${__dirname}/templates/configured/_element.test.js`, templateData);
 	copyFile(
 		`${__dirname}/templates/configured/_element.test.js`,
 		`${getDestinationPath(templateData.hyphenatedName)}/test/${templateData.hyphenatedName}.test.js`
 	);
+	replaceText(`${getDestinationPath(templateData.hyphenatedName)}/test/${templateData.hyphenatedName}.test.js`, templateData);
 
 	copyFilesInDir(`${__dirname}/templates/static`, getDestinationPath(templateData.hyphenatedName));
 }

--- a/src/generators/test-unit/templates/configured/_element.test.js
+++ b/src/generators/test-unit/templates/configured/_element.test.js
@@ -5,7 +5,7 @@ import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-help
 describe('<%= className %>', () => {
 
 	describe('accessibility', () => {
-		it('should pass all axe tests', async() => {
+		it('should pass all aXe tests', async() => {
 			const el = await fixture(html`<<%= tagName %>></<%= tagName %>>`);
 			await expect(el).to.be.accessible();
 		});

--- a/src/generators/test-visual-diff/index.js
+++ b/src/generators/test-visual-diff/index.js
@@ -10,17 +10,17 @@ export function run(templateData) {
 		`${getDestinationPath(templateData.hyphenatedName)}/.gitignore`
 	);
 
-	replaceText(`${__dirname}/templates/_element.visual-diff.js`, templateData);
 	copyFile(
 		`${__dirname}/templates/_element.visual-diff.js`,
 		`${getDestinationPath(templateData.hyphenatedName)}/test/${templateData.hyphenatedName}.visual-diff.js`
 	);
+	replaceText(`${getDestinationPath(templateData.hyphenatedName)}/test/${templateData.hyphenatedName}.visual-diff.js`, templateData);
 
-	replaceText(`${__dirname}/templates/_element.visual-diff.html`, templateData);
 	copyFile(
 		`${__dirname}/templates/_element.visual-diff.html`,
 		`${getDestinationPath(templateData.hyphenatedName)}/test/${templateData.hyphenatedName}.visual-diff.html`
 	);
+	replaceText(`${getDestinationPath(templateData.hyphenatedName)}/test/${templateData.hyphenatedName}.visual-diff.html`, templateData);
 
 	copyFilesInDir(`${__dirname}/templates/static`, getDestinationPath(templateData.hyphenatedName));
 }

--- a/src/generators/wc-lit-element/index.js
+++ b/src/generators/wc-lit-element/index.js
@@ -13,11 +13,11 @@ export function run(templateData) {
 		templateDataElement.localizeMixin = '';
 		templateDataElement.localizeResources = '';
 	}
-	replaceText(`${__dirname}/templates/configured/_element.js`, templateDataElement);
 	copyFile(
 		`${__dirname}/templates/configured/_element.js`,
 		`${getDestinationPath(templateData.hyphenatedName)}/${templateData.hyphenatedName}.js`
 	);
+	replaceText(`${getDestinationPath(templateData.hyphenatedName)}/${templateData.hyphenatedName}.js`, templateDataElement);
 
 	copyFilesInDir(`${__dirname}/templates/static`, getDestinationPath(templateData.hyphenatedName));
 }


### PR DESCRIPTION
Similar to the move vs. copy problem, I noticed that after running the generator once that the replacements had been made in the source files. This switches things around to do replacements _after_ copying the files.