### PR TITLE
Linting: Move localizeConfig

### DIFF
--- a/src/generators/wc-lit-element/templates/configured/_element.js
+++ b/src/generators/wc-lit-element/templates/configured/_element.js
@@ -18,13 +18,13 @@ class <%= className %> extends <%= extends %> {
 			}
 		`;
 	}
-<%= localizeResources %>
+
 	constructor() {
 		super();
 
 		this.prop1 = '<%= hyphenatedName %>';
 	}
-
+<%= localizeResources %>
 	render() {
 		return html`
 			<h2><%= localizeDemo %> ${this.prop1}!</h2>


### PR DESCRIPTION
The existing setup results in a linting error out-of-the-box:
```
29:2 error  Expected constructor to come before static getter localizeConfig  sort-class-members/sort-class-members
```

Just moving the `localizeConfig` bit down under the constructor.