### PR TITLE
feat: removing web component polyfill from demos

### DIFF
--- a/src/generators/demo/templates/_package.json
+++ b/src/generators/demo/templates/_package.json
@@ -3,7 +3,6 @@
     "start": "web-dev-server --app-index demo/index.html --node-resolve --open --watch"
   },
   "devDependencies": {
-    "@web/dev-server": "^0.1",
-    "@webcomponents/webcomponentsjs": "^2"
+    "@web/dev-server": "^0.1"
   }
 }

--- a/src/generators/demo/templates/index.html
+++ b/src/generators/demo/templates/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../<%= hyphenatedName %>.js';


### PR DESCRIPTION
Now that legacy-Edge is pretty much not something we care about anymore, seems like a good time to stop including the polyfill in our demo pages.