### PR TITLE
Fix default serge rewrite config

### DIFF
--- a/src/generators/localization/templates/configured/_element.serge.json
+++ b/src/generators/localization/templates/configured/_element.serge.json
@@ -11,17 +11,13 @@
     "cy-gb cy",
     "da-dk da",
     "de-de de",
-    "es-es es-es",
     "es-mx es",
     "fr-ca fr",
-    "fr-fr fr-fr",
     "ja-jp ja",
     "ko-kr ko",
     "nl-nl nl",
     "pt-br pt",
     "sv-se sv",
-    "tr-tr tr",
-    "zh-cn zh",
-    "zh-tw zh-tw"
+    "tr-tr tr"
   ]
 }


### PR DESCRIPTION
- `es-es`, `fr-fr` and `zh-tw` were being rewritten to themselves
- For political reasons, a base `zh` locale should not be generated from any specific region (other `zh-*` requests should fall back to `en`)