### PR TITLE
referencing the "actions" repo from its new main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Semantic Release
-        uses: BrightspaceUI/actions/semantic-release@master
+        uses: BrightspaceUI/actions/semantic-release@main
         with:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ npm init @brightspace-ui
 
 ### Visual Diff Testing
 
-Visual diff results are published to a bucket in S3 and need special tokens to do so. To set these up, follow the instructions in the [visual-diff GitHub Action](https://github.com/BrightspaceUI/actions/tree/master/visual-diff).
+Visual diff results are published to a bucket in S3 and need special tokens to do so. To set these up, follow the instructions in the [visual-diff GitHub Action](https://github.com/BrightspaceUI/actions/tree/main/visual-diff).
 
 ### Semantic Release
 
 In order for the release workflow to automatically update the version, you need to add brightspace-bot as an admin using the following steps:
 Settings -> Manage access -> Invite teams or people -> Add brightspace-bot
 
-Learn more in the [action docs](https://github.com/BrightspaceUI/actions/blob/master/docs/branch-protection.md).
+Learn more in the [action docs](https://github.com/BrightspaceUI/actions/blob/main/docs/branch-protection.md).
 
 ## Developing and Contributing
 
@@ -58,7 +58,7 @@ Pull requests welcome!
 
 > TL;DR: Commits prefixed with `fix:` and `feat:` will trigger patch and minor releases when merged to `main`. Read on for more details...
 
-The [sematic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/master/semantic-release) is called from the `release.yml` GitHub Action workflow to handle version changes and releasing.
+The [sematic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/main/semantic-release) is called from the `release.yml` GitHub Action workflow to handle version changes and releasing.
 
 ### Version Changes
 

--- a/src/generators/release/templates/configured/_README.md
+++ b/src/generators/release/templates/configured/_README.md
@@ -3,7 +3,7 @@
 
 > TL;DR: Commits prefixed with `fix:` and `feat:` will trigger patch and minor releases when merged to `main`. Read on for more details...
 
-The [sematic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/master/semantic-release) is called from the `release.yml` GitHub Action workflow to handle version changes and releasing.
+The [sematic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/main/semantic-release) is called from the `release.yml` GitHub Action workflow to handle version changes and releasing.
 
 ### Version Changes
 

--- a/src/generators/release/templates/static/.github/workflows/release.yml
+++ b/src/generators/release/templates/static/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: '14'
       - name: Semantic Release
-        uses: BrightspaceUI/actions/semantic-release@master
+        uses: BrightspaceUI/actions/semantic-release@main
         with:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}

--- a/src/generators/test-visual-diff/templates/static/.github/workflows/visual-diff.yml
+++ b/src/generators/test-visual-diff/templates/static/.github/workflows/visual-diff.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Dependencies
         run: npm install
       - name: Visual Diff Tests
-        uses: BrightspaceUI/actions/visual-diff@master
+        uses: BrightspaceUI/actions/visual-diff@main
         with:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Our "actions" repo has had its default branch renamed from `master` to `main`. This just updates to point there.