### PR TITLE
Update stylelint and @brightspace-ui/stylelint-config dependencies.

### DIFF
--- a/src/generators/default-content/templates/configured/_package.json
+++ b/src/generators/default-content/templates/configured/_package.json
@@ -6,13 +6,13 @@
     "lint": "npm run lint:eslint && npm run lint:lit && npm run lint:style",
     "lint:eslint": "eslint . --ext .js,.html",
     "lint:lit": "lit-analyzer <%= hyphenatedName %>.js --strict",
-    "lint:style": "stylelint \"**/*.js\""
+    "lint:style": "stylelint \"**/*.{js,html}\""
   },
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {
     "@babel/eslint-parser": "^7",
-    "@brightspace-ui/stylelint-config": "^0.2",
+    "@brightspace-ui/stylelint-config": "^0.3",
     "eslint": "^7",
     "eslint-config-brightspace": "^0.16",
     "eslint-plugin-html": "^6",
@@ -20,7 +20,7 @@
     "eslint-plugin-lit": "^1",
     "eslint-plugin-sort-class-members": "^1",
     "lit-analyzer": "^1",
-    "stylelint": "^13"
+    "stylelint": "^14"
   },
   "files": [
     "<%= hyphenatedName %>.js"<%= locales %>


### PR DESCRIPTION
This PR updates the `stylelint` and `@brightspace-ui/stylelint-config` dependencies to support `stylelint@v14`. It also updates the linting script command to lint both HTML and JS files.