### PR TITLE
Remove serge rewrite config

### DIFF
--- a/src/generators/localization/templates/configured/_element.serge.json
+++ b/src/generators/localization/templates/configured/_element.serge.json
@@ -5,19 +5,5 @@
   },
   "source_match": "en\\.js$",
   "source_dir": "lang",
-  "output_file_path": "lang/%LANG%.js",
-  "output_lang_rewrite": [
-    "ar-sa ar",
-    "cy-gb cy",
-    "da-dk da",
-    "de-de de",
-    "es-mx es",
-    "fr-ca fr",
-    "ja-jp ja",
-    "ko-kr ko",
-    "nl-nl nl",
-    "pt-br pt",
-    "sv-se sv",
-    "tr-tr tr"
-  ]
+  "output_file_path": "lang/%LANG%.js"
 }


### PR DESCRIPTION
A default `output_lang_rewrite` config has been [implemented](https://github.com/Brightspace/serge-localize/pull/36) and should be relied upon except in special cases.