### PR TITLE
ignoring until Lit 2 upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # Lit 2 upgrade
+      - dependency-name: "@open-wc/testing"
+        versions: ["3.x"]
+      # Lit 2 upgrade
+      - dependency-name: "lit-element"
+        versions: ["3.x"]
+      # Lit 2 upgrade
+      - dependency-name: "lit-html"
+        versions: ["2.x"]


### PR DESCRIPTION
Until we're ready for Lit 2, we need to tell Dependabot to ignore these major versions. Otherwise when someone uses this to generate a new repo, Dependabot will immediately try to upgrade Lit.