### PR TITLE
Switch to Lit 2

### DIFF
--- a/src/generators/default-content/index.js
+++ b/src/generators/default-content/index.js
@@ -43,9 +43,9 @@ export function run(templateData) {
 	if (templateData.codeowners) {
 		copyFile(
 			`${__dirname}/templates/configured/_CODEOWNERS`,
-			`${getDestinationPath(templateData.hyphenatedName)}/CODEOWNERS`
+			`${getDestinationPath(templateData.hyphenatedName)}/.github/CODEOWNERS`
 		);
-		replaceText(`${getDestinationPath(templateData.hyphenatedName)}/CODEOWNERS`, { codeowners: templateData.codeowners });
+		replaceText(`${getDestinationPath(templateData.hyphenatedName)}/.github/CODEOWNERS`, { codeowners: templateData.codeowners });
 	}
 
 	copyFile(

--- a/src/generators/test-unit/templates/configured/_package.json
+++ b/src/generators/test-unit/templates/configured/_package.json
@@ -5,10 +5,10 @@
     "test:headless:watch": "web-test-runner --watch"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^1"
+    "@brightspace-ui/core": "^2"
   },
   "devDependencies": {
-    "@open-wc/testing": "^2",
+    "@open-wc/testing": "^3",
     "@web/test-runner": "^0.13"
   }
 }

--- a/src/generators/wc-lit-element/templates/configured/_element.js
+++ b/src/generators/wc-lit-element/templates/configured/_element.js
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from 'lit-element';
+import { css, html, LitElement } from 'lit';
 <%= localizeMixin %>
 class <%= className %> extends <%= extends %> {
 

--- a/src/generators/wc-lit-element/templates/configured/_package.json
+++ b/src/generators/wc-lit-element/templates/configured/_package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@brightspace-ui/core": "^1",
-    "lit-element": "^2"
+    "@brightspace-ui/core": "^2",
+    "lit": "^2"
   }
 }


### PR DESCRIPTION
Upgrading our NPM init library to use Lit 2. I'll make this a major version bump, even though nothing actually depends on it.