### PR TITLE
Bump eslint-config-brightspace in generated package.json

### DIFF
--- a/src/generators/default-content/templates/configured/_package.json
+++ b/src/generators/default-content/templates/configured/_package.json
@@ -16,7 +16,7 @@
     "@babel/eslint-parser": "^7",
     "@brightspace-ui/stylelint-config": "^0.4",
     "eslint": "^8",
-    "eslint-config-brightspace": "^0.16",
+    "eslint-config-brightspace": "^0.17",
     "eslint-plugin-html": "^6",
     "eslint-plugin-import": "^2",
     "eslint-plugin-lit": "^1",


### PR DESCRIPTION
The change is around `===`, I don't think any other generated code would be affected.