### PR TITLE
fix: escape quotes in wtr calls

### DIFF
--- a/src/generators/test-unit/templates/configured/_package.json
+++ b/src/generators/test-unit/templates/configured/_package.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
     "test": "npm run lint && npm run test:headless",
-    "test:headless": "web-test-runner --files ./test/**/*.test.js --node-resolve",
-    "test:headless:watch": "web-test-runner --files ./test/**/*.test.js --node-resolve --watch"
+    "test:headless": "web-test-runner --files \"./test/**/*.test.js\" --node-resolve",
+    "test:headless:watch": "web-test-runner --files \"./test/**/*.test.js\" --node-resolve --watch"
   },
   "dependencies": {
     "@brightspace-ui/core": "^2"

--- a/src/generators/test-unit/templates/static/.github/workflows/ci.yml
+++ b/src/generators/test-unit/templates/static/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
       - name: Lint (Lit)
         run: npm run lint:lit
       - name: Unit Tests (cross-browser)
-        run: npx web-test-runner --files ./test/**/*.test.js --node-resolve --playwright --browsers chromium firefox webkit
+        run: npx web-test-runner --files "./test/**/*.test.js" --node-resolve --playwright --browsers chromium firefox webkit


### PR DESCRIPTION
We were noticing in CI that without the quotes, only tests inside `test/` would get run, and those inside nested directories would be missed.