### PR TITLE
fix: simplify instructions

### DIFF
--- a/src/generators/test-visual-diff/templates/_README.md
+++ b/src/generators/test-visual-diff/templates/_README.md
@@ -8,10 +8,10 @@ The golden snapshots in source control must be updated by the [visual-diff GitHu
 To run the tests locally to help troubleshoot or develop new tests, first install these dependencies:
 
 ```shell
-npm install @brightspace-ui/visual-diff@X mocha@Y puppeteer@Z  --no-save
+npm install @brightspace-ui/visual-diff@X  --no-save
 ```
 
-Replace `X`, `Y` and `Z` with [the current versions](https://github.com/BrightspaceUI/actions/tree/main/visual-diff#current-dependency-versions) the action is using.
+Replace `X` with [the current versions](https://github.com/BrightspaceUI/actions/tree/main/visual-diff#current-dependency-versions) the action is using.
 
 Then run the tests:
 


### PR DESCRIPTION
These are simpler now that we're using peer dependencies.