### PR TITLE
removing "setup node"

### DIFF
--- a/src/generators/release/templates/static/.github/workflows/release.yml
+++ b/src/generators/release/templates/static/.github/workflows/release.yml
@@ -15,8 +15,7 @@ jobs:
         uses: Brightspace/third-party-actions@actions/checkout
         with:
           persist-credentials: false
-      - name: Setup Node
-        uses: Brightspace/third-party-actions@actions/setup-node
+      - uses: Brightspace/third-party-actions@actions/setup-node
         with:
           node-version-file: .nvmrc
       - name: Semantic Release


### PR DESCRIPTION
First, it should be "set up node" not "setup node". But beyond that, the other workflows don't give this step a name and since it's such a standard thing there really isn't any need.