### PR TITLE
feat: remove localization type option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npm init @brightspace-ui
 
 ### Optional
 
-* Localization (static or dynamic with optional Serge config)
+* Localization
 * Visual diff testing*
 
 \* Some additional setup required (see below)

--- a/src/create.js
+++ b/src/create.js
@@ -59,16 +59,6 @@ async function getOptions() {
 				{ title: 'No', value: false }
 			]
 		},
-		{
-			type: (_, all) => { return all.localization === true ? 'select' : null; },
-			name: 'localizationType',
-			message: 'What type of localization would you like?',
-			choices: [
-				{ title: 'Dynamic (no serge)', value: 'dynamic' },
-				{ title: 'Dynamic (yes serge)', value: 'serge' },
-				{ title: 'Static', value: 'static' }
-			]
-		},
 	];
 	return await prompts(questions, {
 		onCancel: () => {

--- a/src/generators/default-content/index.js
+++ b/src/generators/default-content/index.js
@@ -5,12 +5,7 @@ export function run(templateData) {
 	const replacementsPackage = templateData;
 	replacementsPackage.locales = '';
 	if (templateData.localization) {
-		if (templateData.localizationType === 'serge') {
-			replacementsPackage.locales += `,\n"${templateData.hyphenatedName}.serge.json"`;
-		}
-		if (templateData.localizationType !== 'static') {
-			replacementsPackage.locales += ',\n"/lang"';
-		}
+		replacementsPackage.locales += `,\n"${templateData.hyphenatedName}.serge.json"`;
 	}
 	copyFile(
 		`${__dirname}/templates/configured/_package.json`,

--- a/src/generators/default-content/templates/configured/_package.json
+++ b/src/generators/default-content/templates/configured/_package.json
@@ -12,8 +12,6 @@
   "author": "D2L Corporation",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@babel/core": "^7",
-    "@babel/eslint-parser": "^7",
     "@brightspace-ui/stylelint-config": "^0.7",
     "eslint": "^8",
     "eslint-config-brightspace": "^0.20",

--- a/src/generators/localization/index.js
+++ b/src/generators/localization/index.js
@@ -1,52 +1,25 @@
 import { copyFile, copyFilesInDir, getDestinationPath, replaceText } from '../../helper.js';
 
-const staticLocalization = `\n\tstatic async getLocalizeResources(langs) {
-		const langResources = {
-			'en': { 'hello': 'Hello' },
-			'fr': { 'hello': 'Bonjour' }
-		};
+export function run(templateData) {
 
-		for (let i = 0; i < langs.length; i++) {
-			if (langResources[langs[i]]) {
-				return {
-					language: langs[i],
-					resources: langResources[langs[i]]
-				};
-			}
-		}
-
-		return null;
-	}\n`;
-const dynamicLocalization = `\n\tstatic get localizeConfig() {
+	const replacements = {
+		extends: 'LocalizeMixin(LitElement)',
+		localizeDemo: '${this.localize(\'hello\')}',
+		localizeMixin: 'import { LocalizeMixin } from \'@brightspace-ui/core/mixins/localize/localize-mixin.js\';\n',
+		localizeResources: `\n\tstatic get localizeConfig() {
 		return {
 			importFunc: async lang => (await import(\`./lang/\${lang}.js\`)).default
 		};
-	}\n`;
-
-export function run(templateData) {
-	const replacements = {
-		localizeDemo: '${this.localize(\'hello\')}'
+	}\n`
 	};
-	if (templateData.localizationType === 'static') {
-		replacements.extends = 'LocalizeMixin(LitElement)';
-		replacements.localizeMixin = 'import { LocalizeMixin } from \'@brightspace-ui/core/mixins/localize-mixin.js\';\n';
-		replacements.localizeResourcesDynamic = '';
-		replacements.localizeResourcesStatic = staticLocalization;
-	} else {
-		replacements.extends = 'LocalizeDynamicMixin(LitElement)';
-		replacements.localizeMixin = 'import { LocalizeDynamicMixin } from \'@brightspace-ui/core/mixins/localize-dynamic-mixin.js\';\n';
-		replacements.localizeResourcesDynamic = dynamicLocalization;
-		replacements.localizeResourcesStatic = '';
 
-		copyFilesInDir(`${__dirname}/templates/static`, getDestinationPath(templateData.hyphenatedName));
-	}
+	copyFilesInDir(`${__dirname}/templates/static`, getDestinationPath(templateData.hyphenatedName));
 	replaceText(`${getDestinationPath(templateData.hyphenatedName)}/${templateData.hyphenatedName}.js`, replacements);
 
-	if (templateData.localizationType === 'serge') {
-		copyFile(
-			`${__dirname}/templates/configured/_element.serge.json`,
-			`${getDestinationPath(templateData.hyphenatedName)}/${templateData.hyphenatedName}.serge.json`
-		);
-		replaceText(`${getDestinationPath(templateData.hyphenatedName)}/${templateData.hyphenatedName}.serge.json`, templateData);
-	}
+	copyFile(
+		`${__dirname}/templates/configured/_element.serge.json`,
+		`${getDestinationPath(templateData.hyphenatedName)}/${templateData.hyphenatedName}.serge.json`
+	);
+	replaceText(`${getDestinationPath(templateData.hyphenatedName)}/${templateData.hyphenatedName}.serge.json`, templateData);
+
 }

--- a/src/generators/localization/templates/static/lang/en-gb.js
+++ b/src/generators/localization/templates/static/lang/en-gb.js
@@ -1,0 +1,5 @@
+/* eslint quotes: 0 */
+
+export default {
+	"hello": "Hello"
+};

--- a/src/generators/wc-lit-element/index.js
+++ b/src/generators/wc-lit-element/index.js
@@ -11,8 +11,7 @@ export function run(templateData) {
 		templateDataElement.extends = 'LitElement';
 		templateDataElement.localizeDemo = 'Hello';
 		templateDataElement.localizeMixin = '';
-		templateDataElement.localizeResourcesDynamic = '';
-		templateDataElement.localizeResourcesStatic = '';
+		templateDataElement.localizeResources = '';
 	}
 	copyFile(
 		`${__dirname}/templates/configured/_element.js`,

--- a/src/generators/wc-lit-element/templates/configured/_element.js
+++ b/src/generators/wc-lit-element/templates/configured/_element.js
@@ -18,13 +18,13 @@ class <%= className %> extends <%= extends %> {
 			}
 		`;
 	}
-<%= localizeResourcesStatic %>
+
 	constructor() {
 		super();
 
 		this.prop1 = '<%= hyphenatedName %>';
 	}
-<%= localizeResourcesDynamic %>
+<%= localizeResources %>
 	render() {
 		return html`
 			<h2><%= localizeDemo %> ${this.prop1}!</h2>


### PR DESCRIPTION
Now that `LocalizationStaticMixin` is gone, this removes it from the `npm init` generator.

I also decided that choosing to enable localization in the first place implied that you wanted Serge support. Seems silly not to.