### PR TITLE
fix: remove explicit playwright install

### DIFF
--- a/src/generators/test-unit/templates/static/.github/workflows/ci.yml
+++ b/src/generators/test-unit/templates/static/.github/workflows/ci.yml
@@ -11,10 +11,7 @@ jobs:
         with:
           node-version-file: .nvmrc
       - name: Install dependencies
-        run: |
-          npm install
-          npm install @web/test-runner-playwright --no-save
-          npx playwright install-deps
+        run: npm install
       - name: Lint (JavaScript)
         run: npm run lint:eslint
       - name: Lint (CSS)


### PR DESCRIPTION
This was missed when this repo was [converted to @brightspace-ui/testing](https://github.com/BrightspaceUI/create/pull/82). Our library automatically installs Playwright.