### PR TITLE
fix: restore eslint for tests

### DIFF
--- a/src/generators/test-unit-axe/index.js
+++ b/src/generators/test-unit-axe/index.js
@@ -34,6 +34,10 @@ export function run(templateData) {
 		);
 	}
 
+	copyFile(
+		`${__dirname}/templates/static/test/.eslintrc.json`,
+		`${getDestinationPath(templateData.hyphenatedName)}/test/.eslintrc.json`
+	);
 	replaceText(`${getDestinationPath(templateData.hyphenatedName)}/test/${templateData.hyphenatedName}.test.js`, templateData);
 	replaceText(`${getDestinationPath(templateData.hyphenatedName)}/test/${templateData.hyphenatedName}.axe.js`, templateData);
 	sortJSONMembers(`${getDestinationPath(templateData.hyphenatedName)}/package.json`, ['dependencies', 'devDependencies']);


### PR DESCRIPTION
Looks like this eslint config file for tests got [lost as part of this change](https://github.com/BrightspaceUI/create/pull/94/files#diff-96f7715979e48903f3108fbdce371af4251b8689343c3f675113751c18fba5d4L21).