### PR TITLE
GAUD-9444 - Remove Labs

### DIFF
--- a/src/create.js
+++ b/src/create.js
@@ -87,10 +87,10 @@ async function getComponentOptions() {
 		{
 			type: 'select',
 			name: 'org',
-			message: 'Is this a labs or official component?',
+			message: 'Which GitHub org will this repo be in?',
 			choices: [
-				{ title: 'labs', value: 'labs' },
-				{ title: 'official', value: 'official' }
+				{ title: 'Brightspace', value: 'Brightspace' },
+				{ title: 'BrightspaceUI', value: 'BrightspaceUI' }
 			]
 		},
 		{
@@ -173,10 +173,10 @@ async function executeComponentGenerator() {
 	 */
 	options.hyphenatedName = options.hyphenatedName.toLowerCase();
 	options.className = getClassName(options.hyphenatedName);
-	options.tagName = `d2l-${options.org === 'labs' ? 'labs-' : ''}${options.hyphenatedName}`;
+	options.tagName = `d2l-${options.hyphenatedName}`;
 
-	options.githubOrg = options.org === 'official' ? 'BrightspaceUI' : 'BrightspaceUILabs';
-	options.orgName = options.org === 'official' ? '@brightspace-ui' : '@brightspace-ui-labs';
+	options.githubOrg = options.org;
+	options.orgName = options.org === 'BrightspaceUI' ? '@brightspace-ui' : '@d2l';
 	options.packageName = `${options.orgName}/${options.hyphenatedName}`;
 
 	setupDefaultContent(options);


### PR DESCRIPTION
I don't have time to add an application level component right now, but I figured this could be a small improvement. Removes the Labs option (which we definitely don't want anymore) and instead asks the org the repo is going into, so that piece is set up correctly. Will still have everything set up as public publishing to `npm`, but that's no different/worse than before.

Thoughts? If this seems good I'll create a story.