### PR TITLE
feat: upgrade eslint-config-brightspace (GAUD-9816)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "babel-eslint": "^10",
     "babel-plugin-transform-dynamic-import": "^2",
     "eslint": "^9",
-    "eslint-config-brightspace": "^2",
+    "eslint-config-brightspace": "^3",
     "rimraf": "^6.0.1"
   }
 }

--- a/src/generators/default-content/templates/configured/_package.json
+++ b/src/generators/default-content/templates/configured/_package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@brightspace-ui/stylelint-config": "^2",
     "eslint": "^9",
-    "eslint-config-brightspace": "^2",
+    "eslint-config-brightspace": "^3",
     "stylelint": "^17"
   },
   "files": [


### PR DESCRIPTION
I've tested this out in a new project and no changes to the underlying files were needed to pass linting.