### PR TITLE
Update babel and eslint dependency versions.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,10 +1,9 @@
 module.exports = {
-	plugins: ['babel-plugin-transform-dynamic-import'],
+	plugins: [
+		['polyfill-corejs3', { method: 'usage-global' }]
+	],
 	ignore: ['./src/generators/*/templates/**/*'],
 	presets: [
-		["@babel/preset-env", { targets: { node: '10' } }]
-	],
-	"plugins": [
-		["polyfill-corejs3", { "method": "usage-global" }]
+		['@babel/preset-env', { targets: { node: '10' } }]
 	]
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,15 +2,9 @@ module.exports = {
 	plugins: ['babel-plugin-transform-dynamic-import'],
 	ignore: ['./src/generators/*/templates/**/*'],
 	presets: [
-		[
-			'@babel/env',
-			{
-				targets: {
-					node: '10',
-				},
-				corejs: 2,
-				useBuiltIns: 'usage',
-			},
-		],
+		["@babel/preset-env", { targets: { node: '10' } }]
 	],
+	"plugins": [
+		["polyfill-corejs3", { "method": "usage-global" }]
+	]
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@babel/core": "^8",
     "@babel/preset-env": "^8",
     "babel-plugin-polyfill-corejs3": "^1.0.0",
-    "babel-plugin-transform-dynamic-import": "^2",
     "eslint": "^9",
     "eslint-config-brightspace": "^4",
     "rimraf": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -24,11 +24,10 @@
     "prompts": "^2"
   },
   "devDependencies": {
-    "@babel/cli": "^7",
-    "@babel/core": "^7",
-    "@babel/eslint-parser": "7",
-    "@babel/preset-env": "^7",
-    "babel-eslint": "^10",
+    "@babel/cli": "^8",
+    "@babel/core": "^8",
+    "@babel/preset-env": "^8",
+    "babel-plugin-polyfill-corejs3": "^1.0.0",
     "babel-plugin-transform-dynamic-import": "^2",
     "eslint": "^9",
     "eslint-config-brightspace": "^4",


### PR DESCRIPTION
[GAUD-10214](https://desire2learn.atlassian.net/browse/GAUD-10214)

This PR updates to the v8 `@babel/cli`, `@babel/core`, and `@babel/preset-env` dependencies. Unfortunately this also required a migration to use `babel-plugin-polyfill-corejs3` and an update to the babel config.

It also removes direct dependencies on `@babel/eslint-parser` and `babel-eslint` since we include the parser with our config (our config includes `@babel/eslint-parse`, and  `babel-eslint` was actually deprecated by `@babel/eslint-parse`).

[GAUD-10214]: https://desire2learn.atlassian.net/browse/GAUD-10214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ