### PR TITLE
GAUD-10292: codeartifact & proxy support

### DIFF
--- a/src/create.js
+++ b/src/create.js
@@ -85,15 +85,6 @@ async function getComponentOptions() {
 			message: 'What would you like to name your component? Use hyphenation instead of camelcase. Do not include the d2l prefix.'
 		},
 		{
-			type: 'select',
-			name: 'org',
-			message: 'Which GitHub org will this repo be in?',
-			choices: [
-				{ title: 'Brightspace', value: 'Brightspace' },
-				{ title: 'BrightspaceUI', value: 'BrightspaceUI' }
-			]
-		},
-		{
 			type: 'text',
 			name: 'description',
 			message: 'What is the component description?'
@@ -101,7 +92,7 @@ async function getComponentOptions() {
 		{
 			type: 'text',
 			name: 'codeowners',
-			message: 'What is/are the GitHub username(s) of the codeowner(s)? (e.g., @janesmith, @johnsmith)'
+			message: 'What is the GitHub team that will be CODEOWNERS? (e.g., @Brightspace/team-name)'
 		},
 		{
 			type: 'select',
@@ -170,10 +161,7 @@ async function executeComponentGenerator() {
 	options.hyphenatedName = options.hyphenatedName.toLowerCase();
 	options.className = getClassName(options.hyphenatedName);
 	options.tagName = `d2l-${options.hyphenatedName}`;
-
-	options.githubOrg = options.org;
-	options.orgName = options.org === 'BrightspaceUI' ? '@brightspace-ui' : '@d2l';
-	options.packageName = `${options.orgName}/${options.hyphenatedName}`;
+	options.packageName = `@d2l/${options.hyphenatedName}`;
 
 	setupDefaultContent(options);
 	setupElement(options);

--- a/src/generators/default-content/index.js
+++ b/src/generators/default-content/index.js
@@ -14,18 +14,6 @@ export function run(templateData) {
 	replaceText(`${getDestinationPath(templateData.hyphenatedName)}/package.json`, replacementsPackage);
 
 	const replacementsREADME = templateData;
-	replacementsREADME.labsChecklist = templateData.org === 'labs' ? `\n> Note: this is a ["labs" component](https://daylight.d2l.dev/developing/getting-started/component-tiers/). While functional, these tasks are prerequisites to promotion to BrightspaceUI "official" status:
->
-> - [ ] [Design organization buy-in](https://daylight.d2l.dev/developing/creating-component/before-building/#working-with-design)
-> - [ ] [Architectural sign-off](https://daylight.d2l.dev/developing/creating-component/before-building/#web-component-architecture)
-> - [ ] [Continuous integration](https://daylight.d2l.dev/developing/testing/tools/#continuous-integration)
-> - [ ] [Cross-browser testing](https://daylight.d2l.dev/developing/testing/cross-browser/)
-> - [ ] [Unit tests](https://daylight.d2l.dev/developing/testing/tools/) (if applicable)
-> - [ ] [Accessibility tests](https://daylight.d2l.dev/developing/testing/accessibility/)
-> - [ ] [Visual diff tests](https://daylight.d2l.dev/developing/testing/visual-difference/)
-> - [ ] Localization with Serge (if applicable)
-> - [ ] Demo page
-> - [ ] README documentation\n` : '';
 
 	if (templateData.description) replacementsREADME.description = `\n${templateData.description}\n`;
 	copyFile(

--- a/src/generators/default-content/templates/configured/_README.md
+++ b/src/generators/default-content/templates/configured/_README.md
@@ -1,10 +1,8 @@
 # <%= packageName %>
-
-[![NPM version](https://img.shields.io/npm/v/<%= packageName %>.svg)](https://www.npmjs.org/package/<%= packageName %>)
-<%= labsChecklist %><%= description %>
+<%= description %>
 ## Installation
 
-Install from NPM:
+Install from CodeArtifact:
 
 ```shell
 npm install <%= packageName %>

--- a/src/generators/default-content/templates/configured/_npmrc
+++ b/src/generators/default-content/templates/configured/_npmrc
@@ -1,1 +1,3 @@
+registry=https://npm.package-registry.brightspace.com/
 ignore-scripts=true
+@d2l:registry=https://d2l-569998014834.d.codeartifact.us-east-1.amazonaws.com/npm/private/

--- a/src/generators/default-content/templates/configured/_package.json
+++ b/src/generators/default-content/templates/configured/_package.json
@@ -2,7 +2,7 @@
   "name": "<%= packageName %>",
   "description": "<%= description %>",
   "type": "module",
-  "repository": "https://github.com/<%= githubOrg %>/<%= hyphenatedName %>.git",
+  "repository": "https://github.com/Brightspace/<%= hyphenatedName %>.git",
   "scripts": {
     "lint": "npm run lint:eslint && npm run lint:style",
     "lint:eslint": "eslint .",
@@ -18,8 +18,5 @@
   },
   "files": [
     "<%= hyphenatedName %>.js"<%= locales %>
-  ],
-  "publishConfig": {
-    "access": "public"
-  }
+  ]
 }

--- a/src/generators/demo/templates/_package.json
+++ b/src/generators/demo/templates/_package.json
@@ -3,6 +3,6 @@
     "start": "web-dev-server --app-index demo/index.html --node-resolve --open --watch"
   },
   "devDependencies": {
-    "@web/dev-server": "^0.4"
+    "@web/dev-server": "^1"
   }
 }

--- a/src/generators/release/templates/static/.github/workflows/release.yml
+++ b/src/generators/release/templates/static/.github/workflows/release.yml
@@ -19,7 +19,21 @@ jobs:
         with:
           node-version-file: .nvmrc
           d2l-registry-token: ${{ secrets.D2L_PACKAGE_REGISTRY_AUTH_TOKEN }}
+      - name: Get CodeArtifact authorization token
+        uses: Brightspace/codeartifact-actions/get-authorization-token@main
+        env:
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+          AWS_SESSION_TOKEN: ${{secrets.AWS_SESSION_TOKEN}}
+      - name: Add CodeArtifact npm registry
+        uses: Brightspace/codeartifact-actions/npm/add-registry@main
+        with:
+          auth-token: ${{env.CODEARTIFACT_AUTH_TOKEN}}
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@main
         with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.D2L_RELEASE_TOKEN }}
+          NPM: true


### PR DESCRIPTION
Now that the npm proxy is a thing, this makes a few updates to support it.

It also:
- Just assumes the `Brightspace` organization instead of giving them a choice. We almost never want new repos in `BrightspaceUI` at this point, and if we do it'll be us doing it
- Also assumes CodeArtifact publishing. Again, don't want new public npm things without knowing about it explicitly.
- Some cleanup & upgrades